### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Simon Breuss
 maintainer=Simon Breuss <simon.breuss@gmail.com>
 sentence=Perform an OTA update of the firmware
 paragraph=With this library you can perform an OTA update of the LinkIt ONE
+category=Other
 url=https://github.com/sbreuss/OTAUpdate
 architectures=mtk


### PR DESCRIPTION
This fixes the `WARNING: Category '' in library OTAUpdate is not valid. Setting to 'Uncategorized'` warning on every compile in Arduino IDE 1.6.6+. If you prefer any other [valid category value](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) I'm happy to change it and squash to a single commit.
